### PR TITLE
New prop disableDoubleClickZoomWithToolAuto to disable double click zoom

### DIFF
--- a/src/features/interactions.js
+++ b/src/features/interactions.js
@@ -133,11 +133,13 @@ export function onDoubleClick(event, ViewerDOM, tool, value, props, coords = nul
 
   switch (tool) {
     case TOOL_AUTO:
-      let SVGPoint = getSVGPoint(value, x, y);
-      let modifierKeysReducer = (current, modifierKey) => current || event.getModifierState(modifierKey);
-      let modifierKeyActive = props.modifierKeys.reduce(modifierKeysReducer, false);
-      let scaleFactor = modifierKeyActive ? 1 / props.scaleFactor : props.scaleFactor;
-      nextValue = zoom(value, SVGPoint.x, SVGPoint.y, scaleFactor);
+      if (!props.disableDoubleClickZoomWithToolAuto) {
+        let SVGPoint = getSVGPoint(value, x, y);
+        let modifierKeysReducer = (current, modifierKey) => current || event.getModifierState(modifierKey);
+        let modifierKeyActive = props.modifierKeys.reduce(modifierKeysReducer, false);
+        let scaleFactor = modifierKeyActive ? 1 / props.scaleFactor : props.scaleFactor;
+        nextValue = zoom(value, SVGPoint.x, SVGPoint.y, scaleFactor);
+      }
       break;
 
     default:

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -476,6 +476,9 @@ ReactSVGPanZoom.propTypes = {
   //override miniature component
   customMiniature: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
 
+  //Turn off zoom on double click
+  disableDoubleClickZoomWithToolAuto: PropTypes.bool,
+
   //accept only one node SVG
   children: function (props, propName, componentName) {
     // Only accept a single child, of the appropriate type
@@ -516,4 +519,5 @@ ReactSVGPanZoom.defaultProps = {
   miniatureHeight: 80,
   miniatureBackground: "#616264",
   customMiniature: Miniature,
+  disableZoomWithToolAuto: false
 };

--- a/storybook/stories/ViewerStory.jsx
+++ b/storybook/stories/ViewerStory.jsx
@@ -90,6 +90,8 @@ export default class MainStory extends Component {
           miniaturePosition={select('miniaturePosition', [POSITION_NONE, POSITION_RIGHT, POSITION_LEFT], POSITION_LEFT)}
           miniatureWidth={number('miniatureWidth', 100)}
 
+          disableDoubleClickZoomWithToolAuto={boolean('disableDoubleClickZoomWithToolAuto', false)}
+
           onMouseDown={viewerMouseEventDecorator('onMouseDown')}
           onClick={viewerMouseEventDecorator('onClick')}
           onMouseMove={noArgsDecorator('onMouseMove')}


### PR DESCRIPTION
* New prop disableDoubleClickZoomWithToolAuto simple check in the onDoubleClick handler
* Only affects when tool = TOOL_AUTO
* added to storybook