### PR TITLE
fix: NaN bug caused by not specifying default prop value

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -23,7 +23,7 @@
 | modifierKeys      | -            | Array | Array with modifier keys used with the tool `auto` to swap `zoom in` and `zoom out` ([Accepted value]( https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/getModifierState)) |
 | preventPanOutside | `true`       | Boolean | User can't move the image outside the viewer |
 | scaleFactor       | `1.1`        | Number | How much scale in or out (%) |
-| scaleFactorOnWheel| `1.1`        | Number | how much scale in or out on mouse wheel (requires `detectWheel` enabled) (%) |
+| scaleFactorOnWheel| `1.06`        | Number | how much scale in or out on mouse wheel (requires `detectWheel` to be enabled) (%) |
 | miniaturePosition | `left`       | one of `none`, `right`, `left` | Miniature position |
 | miniatureBackground | `#616264`| String | background of the miniature |
 | miniatureWidth    | `100`        | Number | Miniature width (px) |

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -528,6 +528,7 @@ ReactSVGPanZoom.defaultProps = {
   customToolbar: Toolbar,
   preventPanOutside: true,
   scaleFactor: 1.1,
+  scaleFactorOnWheel: 1.06,
   miniaturePosition: POSITION_LEFT,
   miniatureWidth: 100,
   miniatureHeight: 80,


### PR DESCRIPTION
This occurs when scrolling with the mouse wheel.

Fixes issue #69 