### PR TITLE
[#81] (quick)Fix onClick event on mobile

### DIFF
--- a/src/features/interactions-touch.js
+++ b/src/features/interactions-touch.js
@@ -120,11 +120,7 @@ export function onTouchEnd(event, ViewerDOM, tool, value, props) {
 
   let nextValue = shouldResetPinchPointDistance(event, value, props) ? set(value, { pinchPointDistance: null }) : value;
 
-  if (event.touches.length > 0) {
-    return nextValue;
-  }
-
-  return getNextValue(event, ViewerDOM, tool, nextValue, props, onMouseUp);
+  return nextValue;
 }
 
 export function onTouchCancel(event, ViewerDOM, tool, value, props) {


### PR DESCRIPTION
Related to https://github.com/chrvadala/react-svg-pan-zoom/issues/81

This patch seems to work better on mobile.

Without this patch, **on mobile**, the `onClick` envent on svg elements in  the `<ReactSVGPanZoom>` component is not triggered, so impossible to listen to click event.

This patch make it work again, but I don't know what are the regression it may cause.