### PR TITLE
Support for svg viewbox

### DIFF
--- a/src/features/common.js
+++ b/src/features/common.js
@@ -13,7 +13,7 @@ import {
  * Obtain default value
  * @returns {Object}
  */
-export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax) {
+export function getDefaultValue(viewerWidth, viewerHeight, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax) {
   return set({}, {
     ...identity(),
     version: 2,
@@ -23,6 +23,8 @@ export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, 
     prePinchMode: null,
     viewerWidth,
     viewerHeight,
+    SVGViewBoxX,
+    SVGViewBoxY,
     SVGWidth,
     SVGHeight,
     scaleFactorMin,
@@ -112,12 +114,14 @@ export function setViewerSize(value, viewerWidth, viewerHeight) {
 /**
  *
  * @param value
+ * @param SVGViewBoxX
+ * @param SVGViewBoxY
  * @param SVGWidth
  * @param SVGHeight
  * @returns {Object}
  */
-export function setSVGSize(value, SVGWidth, SVGHeight) {
-  return set(value, {SVGWidth, SVGHeight});
+export function setSVGViewBox(value, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight) {
+  return set(value, {SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight});
 }
 
 /**

--- a/src/features/pan.js
+++ b/src/features/pan.js
@@ -20,8 +20,8 @@ export function pan(value, SVGDeltaX, SVGDeltaY, panLimit = undefined) {
   // apply pan limits
   if (panLimit) {
     let [{x: x1, y: y1}, {x: x2, y: y2}] = applyToPoints(matrix, [
-      {x: panLimit, y: panLimit},
-      {x: value.SVGWidth - panLimit, y: value.SVGHeight - panLimit}
+      {x: value.SVGViewBoxX + panLimit, y: value.SVGViewBoxY + panLimit},
+      {x: value.SVGViewBoxX + value.SVGWidth - panLimit, y: value.SVGViewBoxY + value.SVGHeight - panLimit}
     ]);
 
     //x limit

--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -93,7 +93,7 @@ export function fitSelection(value, selectionSVGPointX, selectionSVGPointY, sele
 }
 
 export function fitToViewer(value) {
-  return fitSelection(value, 0, 0, value.SVGWidth, value.SVGHeight);
+  return fitSelection(value, value.SVGViewBoxX, value.SVGViewBoxY, value.SVGWidth, value.SVGHeight);
 }
 
 export function zoomOnViewerCenter(value, scaleFactor) {

--- a/src/ui-miniature/miniature-mask.jsx
+++ b/src/ui-miniature/miniature-mask.jsx
@@ -4,21 +4,21 @@ import RandomUID from "../utils/RandomUID";
 
 const prefixID = 'react-svg-pan-zoom_miniature'
 
-function MiniatureMask({SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
+function MiniatureMask({SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
   let maskID = `${prefixID}_mask_${_uid}`
 
   return (
     <g>
       <defs>
         <mask id={maskID}>
-          <rect x="0" y="0" width={SVGWidth} height={SVGHeight} fill="#ffffff"/>
+          <rect x={SVGViewBoxX} y={SVGViewBoxY} width={SVGWidth} height={SVGHeight} fill="#ffffff"/>
           <rect x={x1} y={y1} width={x2 - x1} height={y2 - y1}/>
         </mask>
       </defs>
 
       <rect
-        x="0"
-        y="0"
+        x={SVGViewBoxX}
+        y={SVGViewBoxY}
         width={SVGWidth}
         height={SVGHeight}
         style={{
@@ -32,6 +32,8 @@ function MiniatureMask({SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
 }
 
 MiniatureMask.propTypes = {
+  SVGViewBoxX: PropTypes.number.isRequired,
+  SVGViewBoxY: PropTypes.number.isRequired,
   SVGWidth: PropTypes.number.isRequired,
   SVGHeight: PropTypes.number.isRequired,
   x1: PropTypes.number.isRequired,

--- a/src/ui-miniature/miniature.jsx
+++ b/src/ui-miniature/miniature.jsx
@@ -13,7 +13,7 @@ const {min, max} = Math;
 export default function Miniature(props) {
 
   let {value, onChangeValue, position, children, background, SVGBackground, width: miniatureWidth, height: miniatureHeight} = props;
-  let {SVGWidth, SVGHeight, viewerWidth, viewerHeight} = value;
+  let {SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, viewerWidth, viewerHeight} = value;
 
   let ratio = SVGHeight / SVGWidth;
 
@@ -62,8 +62,8 @@ export default function Miniature(props) {
 
             <rect
               fill={SVGBackground}
-              x={0}
-              y={0}
+              x={value.SVGViewBoxX}
+              y={value.SVGViewBoxY}
               width={value.SVGWidth}
               height={value.SVGHeight}/>
 

--- a/src/ui-miniature/miniature.jsx
+++ b/src/ui-miniature/miniature.jsx
@@ -48,8 +48,8 @@ export default function Miniature(props) {
   };
 
   let centerTranslation = ratio >= 1
-    ? `translate(${(miniatureWidth - (SVGWidth * zoomToFit)) / 2 }, 0)`
-    : `translate(0, ${(miniatureHeight - (SVGHeight * zoomToFit)) / 2 })`;
+    ? `translate(${(miniatureWidth - (SVGWidth * zoomToFit)) / 2 }, ${-SVGViewBoxY * zoomToFit})`
+    : `translate(${-SVGViewBoxX * zoomToFit}, ${(miniatureHeight - (SVGHeight * zoomToFit)) / 2 })`;
 
   return (
     <div role="navigation" style={style}>
@@ -70,6 +70,8 @@ export default function Miniature(props) {
             {children}
 
             <MiniatureMask
+              SVGViewBoxX={value.SVGViewBoxX}
+              SVGViewBoxY={value.SVGViewBoxY}
               SVGWidth={SVGWidth}
               SVGHeight={SVGHeight}
               x1={x1}

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -559,8 +559,9 @@ ReactSVGPanZoom.propTypes = {
         ' `' + types.join('`, `') + '`.'
       );
     }
-    if (!prop.props.hasOwnProperty('width') || !prop.props.hasOwnProperty('height')) {
-      return new Error('SVG should have props `width` and `height`');
+    if (!(prop.props.hasOwnProperty('width') && prop.props.hasOwnProperty('height')) &&
+        !prop.props.hasOwnProperty('viewBox')) {
+      return new Error('SVG should have props `width` and `height` or `viewBox`');
     }
 
   }


### PR DESCRIPTION
Support for svg viewbox. if a viewbox is defined, it overrides the svg width and height.
Fixes https://github.com/chrvadala/react-svg-pan-zoom/issues/86.

Allows to write:
```
<ReactSVGPanZoom width={500} height={500}>
        <svg viewBox="40 40 80 80">
...
```