### PR TITLE
Miniature and toolbar buttons to include type="button" attribute

### DIFF
--- a/src/ui-miniature/miniature-toggle-button.jsx
+++ b/src/ui-miniature/miniature-toggle-button.jsx
@@ -22,7 +22,7 @@ export default function MiniatureToggleButton({value, onChangeValue, position}) 
   let action = value.miniatureOpen ? closeMiniature : openMiniature;
 
   return (
-    <button role="button" style={style} onClick={event => onChangeValue(action(value))}>
+    <button role="button" type="button" style={style} onClick={event => onChangeValue(action(value))}>
       <IconArrow open={value.miniatureOpen} position={position}/>
     </button>
   )

--- a/src/ui-toolbar/toolbar-button.jsx
+++ b/src/ui-toolbar/toolbar-button.jsx
@@ -60,7 +60,7 @@ export default class ToolbarButton extends React.Component {
         title={this.props.title}
         name={this.props.name}
         role="button"
-
+        type="button"
       >{this.props.children}</button>
     )
   }


### PR DESCRIPTION
By default type is "submit" and submits the form when the component is used inside one. See https://stackoverflow.com/questions/41904199/whats-the-point-of-button-type-button