### PR TITLE
Added option to align svg while fitting it to the viewer (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,4 @@ yarn add react-svg-pan-zoom
 - [auroranil](https://github.com/auroranil)
 - [ahmedhosny](https://github.com/ahmedhosny)
 - [spcfran](https://github.com/spcfran)
+- [mariafronczak](https://github.com/mariafronczak)

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -43,6 +43,9 @@
 | onTouchMove        | - | `fn(viewerEvent: ViewerTouchEvent)` | Handler* for mousedown |
 | onTouchEnd         | - | `fn(viewerEvent: ViewerTouchEvent)` | Handler* for mousedown |
 | onTouchCancel      | - | `fn(viewerEvent: ViewerTouchEvent)` | Handler* for mousedown |
+| toolbarProps | {} | Object | Toolbar settings |
+| toolbarProps.SVGAlignX | `left` | one of `left`, `center`, `right` | X Alignment used for "Fit to Viewer" action |
+| toolbarProps.SVGAlignY | `top` | one of `top`, `center`, `bottom` | Y Alignment used for "Fit to Viewer" action |
 
 \* handler available only with the tool `none` or `auto`
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,3 +16,9 @@ export const POSITION_LEFT = 'left';
 
 export const ACTION_ZOOM = 'zoom';
 export const ACTION_PAN = 'pan';
+
+export const ALIGN_CENTER = 'center';
+export const ALIGN_LEFT = 'left';
+export const ALIGN_RIGHT = 'right';
+export const ALIGN_TOP = 'top';
+export const ALIGN_BOTTOM = 'bottom';

--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -105,7 +105,7 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
   const scaleMatrix = scale(scaleLevel, scaleLevel);
   let translationMatrix = translate(0, 0);
 
-  // after fitting SVG and the viewer will match either in width (1) or in height (2)
+  // after fitting, SVG and the viewer will match in width (1) or in height (2)
   if (scaleX < scaleY) {
     //(1) match in width, meaning scaled SVGHeight <= viewerHeight
     let remainderY = viewerHeight - scaleX * SVGHeight;

--- a/src/ui-toolbar/toolbar.jsx
+++ b/src/ui-toolbar/toolbar.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {
   TOOL_NONE, TOOL_PAN, TOOL_ZOOM_IN, TOOL_ZOOM_OUT,
   POSITION_TOP, POSITION_RIGHT, POSITION_BOTTOM, POSITION_LEFT,
+  ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT, ALIGN_TOP, ALIGN_BOTTOM,
 } from '../constants';
 
 import {fitToViewer} from '../features/zoom';
@@ -13,7 +14,7 @@ import IconZoomOut from './icon-zoom-out';
 import IconFit from './icon-fit';
 import ToolbarButton from './toolbar-button';
 
-export default function Toolbar({tool, value, onChangeValue, onChangeTool, position}) {
+export default function Toolbar({tool, value, onChangeValue, onChangeTool, position, SVGAlignX, SVGAlignY}) {
 
   let handleChangeTool = (event, tool) => {
     onChangeTool(tool);
@@ -22,7 +23,7 @@ export default function Toolbar({tool, value, onChangeValue, onChangeTool, posit
   };
 
   let handleFit = event => {
-    onChangeValue(fitToViewer(value));
+    onChangeValue(fitToViewer(value, SVGAlignX, SVGAlignY));
     event.stopPropagation();
     event.preventDefault();
   };
@@ -102,4 +103,11 @@ Toolbar.propTypes = {
   value: PropTypes.object.isRequired,
   onChangeValue: PropTypes.func.isRequired,
   onChangeTool: PropTypes.func.isRequired,
+  SVGAlignX: PropTypes.oneOf([ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
+  SVGAlignY: PropTypes.oneOf([ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
+};
+
+Toolbar.defaultProps = {
+  SVGAlignX: ALIGN_LEFT,
+  SVGAlignY: ALIGN_TOP
 };

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -141,8 +141,8 @@ export default class ReactSVGPanZoom extends React.Component {
     this.setValue(nextValue);
   }
 
-  fitToViewer() {
-    let nextValue = fitToViewer(this.getValue(), this.props.SVGAlignX, this.props.SVGAlignY);
+  fitToViewer(SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
+    let nextValue = fitToViewer(this.getValue(), SVGAlignX, SVGAlignY);
     this.setValue(nextValue);
   }
 
@@ -387,7 +387,7 @@ export default class ReactSVGPanZoom extends React.Component {
             onChangeValue={value => this.setValue(value)}
             tool={tool}
             onChangeTool={tool => this.changeTool(tool)}
-            SVGAlignX={props.SVGAlignX} SVGAlignY={props.SVGAlignY} />}
+            {...this.props.toolbarProps} />}
 
         {props.miniaturePosition === POSITION_NONE ? null :
           <CustomMiniature
@@ -532,11 +532,8 @@ ReactSVGPanZoom.propTypes = {
   //Turn off zoom on double click
   disableDoubleClickZoomWithToolAuto: PropTypes.bool,
 
-  //SVG horizontal alignment for fitToViewer
-  SVGAlignX: PropTypes.oneOf([ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
-
-  //SVG vertical alignment for fitToViewer
-  SVGAlignY: PropTypes.oneOf([ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
+  //toolbar props
+  toolbarProps: PropTypes.object,
 
   //accept only one node SVG
   children: function (props, propName, componentName) {
@@ -583,6 +580,5 @@ ReactSVGPanZoom.defaultProps = {
   disableZoomWithToolAuto: false,
   onZoom: null,
   onPan: null,
-  SVGAlignX: ALIGN_LEFT,
-  SVGAlignY: ALIGN_TOP
+  toolbarProps: {}
 };

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -533,7 +533,10 @@ ReactSVGPanZoom.propTypes = {
   disableDoubleClickZoomWithToolAuto: PropTypes.bool,
 
   //toolbar props
-  toolbarProps: PropTypes.object,
+  toolbarProps: PropTypes.shape({
+    SVGAlignX: PropTypes.oneOf([ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
+    SVGAlignY: PropTypes.oneOf([ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
+  }),
 
   //accept only one node SVG
   children: function (props, propName, componentName) {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -46,7 +46,8 @@ import {
   TOOL_AUTO, TOOL_NONE, TOOL_PAN, TOOL_ZOOM_IN, TOOL_ZOOM_OUT,
   MODE_IDLE, MODE_PANNING, MODE_ZOOMING,
   POSITION_NONE, POSITION_TOP, POSITION_RIGHT, POSITION_BOTTOM, POSITION_LEFT,
-  ACTION_PAN, ACTION_ZOOM
+  ACTION_PAN, ACTION_ZOOM,
+  ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT, ALIGN_TOP, ALIGN_BOTTOM
 } from './constants';
 
 export default class ReactSVGPanZoom extends React.Component {
@@ -141,7 +142,7 @@ export default class ReactSVGPanZoom extends React.Component {
   }
 
   fitToViewer() {
-    let nextValue = fitToViewer(this.getValue());
+    let nextValue = fitToViewer(this.getValue(), this.props.SVGAlignX, this.props.SVGAlignY);
     this.setValue(nextValue);
   }
 
@@ -213,7 +214,6 @@ export default class ReactSVGPanZoom extends React.Component {
       requestAnimationFrame(this.autoPanLoop);
     }
   }
-
 
   componentDidMount() {
     let {props, state} = this;
@@ -386,7 +386,8 @@ export default class ReactSVGPanZoom extends React.Component {
             value={value}
             onChangeValue={value => this.setValue(value)}
             tool={tool}
-            onChangeTool={tool => this.changeTool(tool)}/>}
+            onChangeTool={tool => this.changeTool(tool)}
+            SVGAlignX={props.SVGAlignX} SVGAlignY={props.SVGAlignY} />}
 
         {props.miniaturePosition === POSITION_NONE ? null :
           <CustomMiniature
@@ -531,6 +532,12 @@ ReactSVGPanZoom.propTypes = {
   //Turn off zoom on double click
   disableDoubleClickZoomWithToolAuto: PropTypes.bool,
 
+  //SVG horizontal alignment for fitToViewer
+  SVGAlignX: PropTypes.oneOf([ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
+
+  //SVG vertical alignment for fitToViewer
+  SVGAlignY: PropTypes.oneOf([ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
+
   //accept only one node SVG
   children: function (props, propName, componentName) {
     // Only accept a single child, of the appropriate type
@@ -576,4 +583,6 @@ ReactSVGPanZoom.defaultProps = {
   disableZoomWithToolAuto: false,
   onZoom: null,
   onPan: null,
+  SVGAlignX: ALIGN_LEFT,
+  SVGAlignY: ALIGN_TOP
 };

--- a/storybook/stories/DifferentSizesStory.jsx
+++ b/storybook/stories/DifferentSizesStory.jsx
@@ -1,9 +1,10 @@
 import React, {Component} from 'react';
+import {select} from '@storybook/addon-knobs';
 
 import {
   ReactSVGPanZoom,
+  ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT, ALIGN_TOP, ALIGN_BOTTOM
 } from '../../src/index';
-
 
 export default class DifferentSizesStory extends Component {
   constructor(props) {
@@ -29,7 +30,12 @@ export default class DifferentSizesStory extends Component {
         <ReactSVGPanZoom
           width={600} height={400}
           detectAutoPan={false}
-          ref={Viewer => this.Viewer1 = Viewer}>
+          toolbarProps={{
+            SVGAlignX: select('toolbarProps.SVGAlignX', [ALIGN_LEFT, ALIGN_CENTER, ALIGN_RIGHT]),
+            SVGAlignY: select('toolbarProps.SVGAlignY', [ALIGN_TOP, ALIGN_CENTER, ALIGN_BOTTOM]),
+          }}
+          ref={Viewer => this.Viewer1 = Viewer}
+        >
           <svg width={300} height={600}>
             <rect x="20" y="20" width="260" height="560" fill="green" stroke="black"/>
             <text x="20" y="15">300x600</text>
@@ -41,7 +47,12 @@ export default class DifferentSizesStory extends Component {
         <ReactSVGPanZoom
           width={600} height={400}
           detectAutoPan={false}
-          ref={Viewer => this.Viewer2 = Viewer}>
+          toolbarProps={{
+            SVGAlignX: select('toolbarProps.SVGAlignX', [ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
+            SVGAlignY: select('toolbarProps.SVGAlignY', [ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
+          }}
+          ref={Viewer => this.Viewer2 = Viewer}
+        >
           <svg width={600} height={300}>
             <rect x="20" y="20" width="560" height="260" fill="red" stroke="black"/>
             <text x="20" y="15">600x300</text>
@@ -53,7 +64,12 @@ export default class DifferentSizesStory extends Component {
         <ReactSVGPanZoom
           width={400} height={600}
           detectAutoPan={false}
-          ref={Viewer => this.Viewer3 = Viewer}>
+          toolbarProps={{
+            SVGAlignX: select('toolbarProps.SVGAlignX', [ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
+            SVGAlignY: select('toolbarProps.SVGAlignY', [ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
+          }}
+          ref={Viewer => this.Viewer3 = Viewer}
+        >
           <svg width={300} height={600}>
             <rect x="20" y="20" width="260" height="560" fill="yellow" stroke="black"/>
             <text x="20" y="15">300x600</text>
@@ -65,7 +81,12 @@ export default class DifferentSizesStory extends Component {
         <ReactSVGPanZoom
           width={400} height={600}
           detectAutoPan={false}
-          ref={Viewer => this.Viewer4 = Viewer}>
+          toolbarProps={{
+            SVGAlignX: select('toolbarProps.SVGAlignX', [ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
+            SVGAlignY: select('toolbarProps.SVGAlignY', [ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
+          }}
+          ref={Viewer => this.Viewer4 = Viewer}
+        >
           <svg width={600} height={300}>
             <rect x="20" y="20" width="560" height="260" fill="blue" stroke="black"/>
             <text x="20" y="15">600x300</text>
@@ -77,7 +98,12 @@ export default class DifferentSizesStory extends Component {
         <ReactSVGPanZoom
           width={400} height={400}
           detectAutoPan={false}
-          ref={Viewer => this.Viewer5 = Viewer}>
+          toolbarProps={{
+            SVGAlignX: select('toolbarProps.SVGAlignX', [ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
+            SVGAlignY: select('toolbarProps.SVGAlignY', [ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
+          }}
+          ref={Viewer => this.Viewer5 = Viewer}
+        >
           <svg width={300} height={300}>
             <rect x="20" y="20" width="260" height="260" fill="blue" stroke="black"/>
             <text x="20" y="15">400x400</text>

--- a/storybook/stories/ViewerStory.jsx
+++ b/storybook/stories/ViewerStory.jsx
@@ -6,7 +6,8 @@ import {noArgsDecorator, viewerTouchEventDecorator, viewerMouseEventDecorator} f
 import {
   ReactSVGPanZoom,
   TOOL_NONE, TOOL_AUTO, TOOL_PAN, TOOL_ZOOM_IN, TOOL_ZOOM_OUT,
-  POSITION_NONE, POSITION_TOP, POSITION_RIGHT, POSITION_BOTTOM, POSITION_LEFT
+  POSITION_NONE, POSITION_TOP, POSITION_RIGHT, POSITION_BOTTOM, POSITION_LEFT,
+  ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT, ALIGN_TOP, ALIGN_BOTTOM,
 } from '../../src/index';
 import Snake from './snake.svg';
 
@@ -109,6 +110,11 @@ export default class MainStory extends Component {
 
           scaleFactorMin={number('scaleFactorMin', 0)}
           scaleFactorMax={number('scaleFactorMax', 999999)}
+
+          toolbarProps={{
+            SVGAlignX: select('toolbarProps.SVGAlignX', [ALIGN_LEFT, ALIGN_CENTER, ALIGN_RIGHT]),
+            SVGAlignY: select('toolbarProps.SVGAlignY', [ALIGN_TOP, ALIGN_CENTER, ALIGN_BOTTOM]),
+          }}
         >
 
           <svg width={1440} height={1440}>


### PR DESCRIPTION
Alignment can be passed as optional props `SVGAlignX` and `SVGAlignY` to ReactSVGPanZoom and Toolbar components; or via arguments to the base `fitToViewer` function.
(What is passed to ReactSVGPanZoom will also be passed to the toolbar.)

Default alignment values are provided - aligning to top left, as before.

I will need the ability to fit and center svgs in one of my projects, so I thought I might as well write a bit more general solution for left/center/top horizontal alignment and top/center/bottom vertical alignment..