### PR TITLE
add rotate functionality

### DIFF
--- a/src/features/rotate.js
+++ b/src/features/rotate.js
@@ -1,0 +1,19 @@
+import {transform, fromObject, rotate as rotateTransformation} from 'transformation-matrix';
+
+import {set, getSVGPoint} from './common';
+
+export function rotateOnCenter(value, rotateFactor) {
+  let {viewerWidth, viewerHeight} = value;
+  let SVGPoint = getSVGPoint(value, viewerWidth / 2, viewerHeight / 2);
+  
+  const matrix = transform(
+    fromObject(value),
+    rotateTransformation(rotateFactor, SVGPoint.x, SVGPoint.y)
+  );
+
+  return set(value, {
+    ...matrix,
+  });
+}
+
+

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {setPointOnViewerCenter, reset} from './features/common';
 export {pan} from './features/pan';
 export {zoom, fitSelection, fitToViewer, zoomOnViewerCenter} from './features/zoom';
 export {openMiniature, closeMiniature} from './features/miniature'
+export {rotateOnCenter} from './features/rotate'
 export * from './constants';
 
 export const Viewer = () => {

--- a/storybook/stories/RotateStory.jsx
+++ b/storybook/stories/RotateStory.jsx
@@ -1,0 +1,45 @@
+import React, { Component } from 'react';
+import { ReactSVGPanZoom, TOOL_NONE, rotateOnCenter } from '../../src/index';
+
+export default class RotateStory extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: null,
+      tool: TOOL_NONE
+    };
+  }
+
+  componentDidMount() {
+    this.Viewer.fitToViewer();
+  }
+
+  render() {
+    return (
+      <div>
+        <button className="btn" onClick={event => this.setState({ value: rotateOnCenter(this.state.value, Math.PI / 2) })}>Rotate 90°
+        </button>
+
+        <hr />
+
+        <ReactSVGPanZoom
+          width={400} height={400} style={{ border: "1px solid black" }}
+          ref={Viewer => this.Viewer = Viewer}
+          detectAutoPan={false}
+
+          value={this.state.value} onChangeValue={value => this.setState({ value })}
+          tool={this.state.tool} onChangeTool={tool => this.setState({ tool })}>
+
+          <svg width={800} height={800}>
+            <rect x="400" y="40" width="100" height="200" fill="#4286f4" stroke="#f4f142" />
+            <circle cx="108" cy="108.5" r="100" fill="#0ff" stroke="#0ff" />
+            <circle cx="180" cy="209.5" r="100" fill="#ff0" stroke="#ff0" />
+            <circle cx="220" cy="109.5" r="100" fill="#f0f" stroke="#f0f" />
+          </svg>
+
+        </ReactSVGPanZoom>
+
+      </div>
+    );
+  }
+}

--- a/storybook/stories/index.js
+++ b/storybook/stories/index.js
@@ -9,6 +9,7 @@ import MethodsStory from './MethodsStory'
 import AutosizerViewer from './AutosizerViewer'
 import DifferentSizesStory from './DifferentSizesStory';
 import RuntimeResizeStory from "./RuntimeResizeStory";
+import RotateStory from './RotateStory';
 
 storiesOf('React SVG Pan Zoom', module)
   .addDecorator(withKnobs)
@@ -18,5 +19,6 @@ storiesOf('React SVG Pan Zoom', module)
   .add('Autosizer viewer', () => <AutosizerViewer />)
   .add('Different Sizes', () => <DifferentSizesStory />)
   .add('Runtime Resize', () =>  <RuntimeResizeStory />)
+  .add('Rotate', () => <RotateStory/>)
 
 


### PR DESCRIPTION
This adds rotate to the available features.  I could use some advice before this gets merged, because it causes an error to be logged even though it appears to work in the storybook.

`Error: <rect> attribute height: A negative value is not valid. ("-800")` in react-dom

I don't understand why it's doing that.  Maybe it would be better to do the rotation using the svg `rotate()` transformation instead of `matrix()`?