### PR TITLE
Compare to SVGHeight instead of prevSVGHeight

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -103,7 +103,7 @@ export default class ReactSVGPanZoom extends React.Component {
     let {width: prevSVGWidth, height: prevSVGHeight} = prevProps.children.props;
     if (
       prevSVGWidth !== SVGWidth ||
-      prevSVGHeight !== prevSVGHeight
+      prevSVGHeight !== SVGHeight
     ) {
       nextValue = setSVGSize(nextValue, SVGWidth, SVGHeight);
       needUpdate = true;


### PR DESCRIPTION
Fixes a bug that causes the viewer not to update when changing height of the embedded SVG.