### PR TITLE
Bug fix. POSITION_NONE is a valid prop value for the position attribute in toolbarProps

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -569,7 +569,7 @@ ReactSVGPanZoom.propTypes = {
 
   //toolbar props
   toolbarProps: PropTypes.shape({
-    position: PropTypes.oneOf([POSITION_TOP, POSITION_RIGHT, POSITION_BOTTOM, POSITION_LEFT]),
+    position: PropTypes.oneOf([POSITION_NONE, POSITION_TOP, POSITION_RIGHT, POSITION_BOTTOM, POSITION_LEFT]),
     SVGAlignX: PropTypes.oneOf([ALIGN_CENTER, ALIGN_LEFT, ALIGN_RIGHT]),
     SVGAlignY: PropTypes.oneOf([ALIGN_CENTER, ALIGN_TOP, ALIGN_BOTTOM]),
   }),


### PR DESCRIPTION
v3 Bug fix. POSITION_NONE is a valid prop value for the position attribute in toolbarProps.