### PR TITLE
SVG viewbox support (2.0)

### DIFF
--- a/src/features/common.js
+++ b/src/features/common.js
@@ -120,7 +120,7 @@ export function setViewerSize(value, viewerWidth, viewerHeight) {
  * @param SVGY
  * @returns {Object}
  */
-export function setSVGSize(value, SVGWidth, SVGHeight, SVGX, SVGY) {
+export function setSVGSize(value, SVGWidth, SVGHeight, SVGX = 0, SVGY = 0) {
   return set(value, {SVGWidth, SVGHeight, SVGX, SVGY});
 }
 

--- a/src/features/common.js
+++ b/src/features/common.js
@@ -13,7 +13,7 @@ import {
  * Obtain default value
  * @returns {Object}
  */
-export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax) {
+export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGX, SVGY, scaleFactorMin, scaleFactorMax) {
   return set({}, {
     ...identity(),
     version: 2,
@@ -25,6 +25,8 @@ export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, 
     viewerHeight,
     SVGWidth,
     SVGHeight,
+    SVGX,
+    SVGY,
     scaleFactorMin,
     scaleFactorMax,
     startX: null,
@@ -114,10 +116,12 @@ export function setViewerSize(value, viewerWidth, viewerHeight) {
  * @param value
  * @param SVGWidth
  * @param SVGHeight
+ * @param SVGX
+ * @param SVGY
  * @returns {Object}
  */
-export function setSVGSize(value, SVGWidth, SVGHeight) {
-  return set(value, {SVGWidth, SVGHeight});
+export function setSVGSize(value, SVGWidth, SVGHeight, SVGX, SVGY) {
+  return set(value, {SVGWidth, SVGHeight, SVGX, SVGY});
 }
 
 /**

--- a/src/features/common.js
+++ b/src/features/common.js
@@ -13,7 +13,7 @@ import {
  * Obtain default value
  * @returns {Object}
  */
-export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGX, SVGY, scaleFactorMin, scaleFactorMax) {
+export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGX = 0, SVGY = 0, scaleFactorMin, scaleFactorMax) {
   return set({}, {
     ...identity(),
     version: 2,

--- a/src/features/common.js
+++ b/src/features/common.js
@@ -23,10 +23,10 @@ export function getDefaultValue(viewerWidth, viewerHeight, SVGViewBoxX, SVGViewB
     prePinchMode: null,
     viewerWidth,
     viewerHeight,
-    SVGWidth,
-    SVGHeight,
     SVGViewBoxX,
     SVGViewBoxY,
+    SVGWidth,
+    SVGHeight,
     scaleFactorMin,
     scaleFactorMax,
     startX: null,
@@ -114,14 +114,14 @@ export function setViewerSize(value, viewerWidth, viewerHeight) {
 /**
  *
  * @param value
- * @param SVGWidth
- * @param SVGHeight
  * @param SVGViewBoxX
  * @param SVGViewBoxY
+ * @param SVGWidth
+ * @param SVGHeight
  * @returns {Object}
  */
 export function setSVGViewBox(value, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight) {
-  return set(value, {SVGWidth, SVGHeight, SVGViewBoxX, SVGViewBoxY});
+  return set(value, {SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight});
 }
 
 /**

--- a/src/features/common.js
+++ b/src/features/common.js
@@ -13,7 +13,7 @@ import {
  * Obtain default value
  * @returns {Object}
  */
-export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGX = 0, SVGY = 0, scaleFactorMin, scaleFactorMax) {
+export function getDefaultValue(viewerWidth, viewerHeight, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax) {
   return set({}, {
     ...identity(),
     version: 2,
@@ -25,8 +25,8 @@ export function getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, 
     viewerHeight,
     SVGWidth,
     SVGHeight,
-    SVGX,
-    SVGY,
+    SVGViewBoxX,
+    SVGViewBoxY,
     scaleFactorMin,
     scaleFactorMax,
     startX: null,
@@ -116,12 +116,12 @@ export function setViewerSize(value, viewerWidth, viewerHeight) {
  * @param value
  * @param SVGWidth
  * @param SVGHeight
- * @param SVGX
- * @param SVGY
+ * @param SVGViewBoxX
+ * @param SVGViewBoxY
  * @returns {Object}
  */
-export function setSVGSize(value, SVGWidth, SVGHeight, SVGX = 0, SVGY = 0) {
-  return set(value, {SVGWidth, SVGHeight, SVGX, SVGY});
+export function setSVGViewBox(value, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight) {
+  return set(value, {SVGWidth, SVGHeight, SVGViewBoxX, SVGViewBoxY});
 }
 
 /**

--- a/src/features/common.js
+++ b/src/features/common.js
@@ -13,7 +13,7 @@ import {
  * Obtain default value
  * @returns {Object}
  */
-export function getDefaultValue(viewerWidth, viewerHeight, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax) {
+export function getDefaultValue(viewerWidth, viewerHeight, SVGMinX, SVGMinY, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax) {
   return set({}, {
     ...identity(),
     version: 2,
@@ -23,8 +23,8 @@ export function getDefaultValue(viewerWidth, viewerHeight, SVGViewBoxX, SVGViewB
     prePinchMode: null,
     viewerWidth,
     viewerHeight,
-    SVGViewBoxX,
-    SVGViewBoxY,
+    SVGMinX,
+    SVGMinY,
     SVGWidth,
     SVGHeight,
     scaleFactorMin,
@@ -114,14 +114,14 @@ export function setViewerSize(value, viewerWidth, viewerHeight) {
 /**
  *
  * @param value
- * @param SVGViewBoxX
- * @param SVGViewBoxY
+ * @param SVGMinX
+ * @param SVGMinY
  * @param SVGWidth
  * @param SVGHeight
  * @returns {Object}
  */
-export function setSVGViewBox(value, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight) {
-  return set(value, {SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight});
+export function setSVGViewBox(value, SVGMinX, SVGMinY, SVGWidth, SVGHeight) {
+  return set(value, {SVGMinX, SVGMinY, SVGWidth, SVGHeight});
 }
 
 /**

--- a/src/features/pan.js
+++ b/src/features/pan.js
@@ -20,8 +20,8 @@ export function pan(value, SVGDeltaX, SVGDeltaY, panLimit = undefined) {
   // apply pan limits
   if (panLimit) {
     let [{x: x1, y: y1}, {x: x2, y: y2}] = applyToPoints(matrix, [
-      {x: panLimit, y: panLimit},
-      {x: value.SVGWidth - panLimit, y: value.SVGHeight - panLimit}
+      {x: value.SVGViewBoxX + panLimit, y:  value.SVGViewBoxY + panLimit},
+      {x: value.SVGViewBoxX + value.SVGWidth - panLimit, y: value.SVGViewBoxY + value.SVGHeight - panLimit}
     ]);
 
     //x limit

--- a/src/features/pan.js
+++ b/src/features/pan.js
@@ -20,7 +20,7 @@ export function pan(value, SVGDeltaX, SVGDeltaY, panLimit = undefined) {
   // apply pan limits
   if (panLimit) {
     let [{x: x1, y: y1}, {x: x2, y: y2}] = applyToPoints(matrix, [
-      {x: value.SVGViewBoxX + panLimit, y:  value.SVGViewBoxY + panLimit},
+      {x: value.SVGViewBoxX + panLimit, y: value.SVGViewBoxY + panLimit},
       {x: value.SVGViewBoxX + value.SVGWidth - panLimit, y: value.SVGViewBoxY + value.SVGHeight - panLimit}
     ]);
 

--- a/src/features/pan.js
+++ b/src/features/pan.js
@@ -20,8 +20,8 @@ export function pan(value, SVGDeltaX, SVGDeltaY, panLimit = undefined) {
   // apply pan limits
   if (panLimit) {
     let [{x: x1, y: y1}, {x: x2, y: y2}] = applyToPoints(matrix, [
-      {x: value.SVGViewBoxX + panLimit, y: value.SVGViewBoxY + panLimit},
-      {x: value.SVGViewBoxX + value.SVGWidth - panLimit, y: value.SVGViewBoxY + value.SVGHeight - panLimit}
+      {x: value.SVGMinX + panLimit, y: value.SVGMinY + panLimit},
+      {x: value.SVGMinX + value.SVGWidth - panLimit, y: value.SVGMinY + value.SVGHeight - panLimit}
     ]);
 
     //x limit

--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -96,14 +96,14 @@ export function fitSelection(value, selectionSVGPointX, selectionSVGPointY, sele
 }
 
 export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
-  let {viewerWidth, viewerHeight, SVGWidth, SVGHeight} = value;
+  let {viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGX, SVGY} = value;
 
   let scaleX = viewerWidth / SVGWidth;
   let scaleY = viewerHeight / SVGHeight;
   let scaleLevel = Math.min(scaleX, scaleY);
 
   const scaleMatrix = scale(scaleLevel, scaleLevel);
-  let translationMatrix = translate(0, 0);
+  let translationMatrix = translate(-SVGX * scaleX, -SVGY / scaleY);
 
   // after fitting, SVG and the viewer will match in width (1) or in height (2)
   if (scaleX < scaleY) {
@@ -111,18 +111,18 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
     let remainderY = viewerHeight - scaleX * SVGHeight;
 
     if (SVGAlignY === ALIGN_CENTER)
-      translationMatrix = translate(0, Math.round(remainderY / 2));
+      translationMatrix = translate(-SVGX * scaleX, (Math.round(remainderY / 2) - SVGY) * scaleY);
     if (SVGAlignY === ALIGN_BOTTOM)
-      translationMatrix = translate(0, remainderY);
+      translationMatrix = translate(-SVGX * scaleX, (remainderY - SVGY) * scaleY);
   }
   else {
     //(2) match in height, meaning scaled SVGWidth <= viewerWidth
     let remainderX = viewerWidth - scaleY * SVGWidth;
 
     if (SVGAlignX === ALIGN_CENTER)
-      translationMatrix = translate(Math.round(remainderX / 2), 0);
+      translationMatrix = translate((Math.round(remainderX / 2) - SVGX) * scaleX, -SVGY * scaleY);
     if (SVGAlignX === ALIGN_RIGHT)
-      translationMatrix = translate(remainderX, 0);
+      translationMatrix = translate((remainderX - SVGX) * scaleX, -SVGY * scaleY);
   }
 
   const matrix = transform(

--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -96,34 +96,51 @@ export function fitSelection(value, selectionSVGPointX, selectionSVGPointY, sele
 }
 
 export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
-  let {viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGViewBoxX, SVGViewBoxY} = value;
+  let {viewerWidth, viewerHeight, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight} = value;
 
   let scaleX = viewerWidth / SVGWidth;
   let scaleY = viewerHeight / SVGHeight;
   let scaleLevel = Math.min(scaleX, scaleY);
 
   const scaleMatrix = scale(scaleLevel, scaleLevel);
-  let translationMatrix = translate(-SVGViewBoxX * scaleX, -SVGViewBoxY * scaleY);
+
+  let translateX = -SVGViewBoxX * scaleX;
+  let translateY = -SVGViewBoxY * scaleY;
 
   // after fitting, SVG and the viewer will match in width (1) or in height (2)
   if (scaleX < scaleY) {
     //(1) match in width, meaning scaled SVGHeight <= viewerHeight
     let remainderY = viewerHeight - scaleX * SVGHeight;
-
-    if (SVGAlignY === ALIGN_CENTER)
-      translationMatrix = translate(-SVGViewBoxX * scaleX, (Math.round(remainderY / 2) - SVGViewBoxY) * scaleY);
-    if (SVGAlignY === ALIGN_BOTTOM)
-      translationMatrix = translate(-SVGViewBoxX * scaleX, (remainderY - SVGViewBoxY) * scaleY);
+    switch(SVGAlignY) {
+      case ALIGN_TOP:
+        translateY = -SVGViewBoxY * scaleY / 2;
+      break;
+      case ALIGN_CENTER:
+        translateY = Math.round(remainderY / 2) - SVGViewBoxY * scaleY / 2;
+      break;
+      case ALIGN_BOTTOM:
+        translateY = remainderY - SVGViewBoxY * scaleY / 2;
+      break;
+    }
   }
   else {
     //(2) match in height, meaning scaled SVGWidth <= viewerWidth
     let remainderX = viewerWidth - scaleY * SVGWidth;
-
-    if (SVGAlignX === ALIGN_CENTER)
-      translationMatrix = translate((Math.round(remainderX / 2) - SVGViewBoxX) * scaleX, -SVGViewBoxY * scaleY);
-    if (SVGAlignX === ALIGN_RIGHT)
-      translationMatrix = translate((remainderX - SVGViewBoxX) * scaleX, -SVGViewBoxY * scaleY);
+    switch(SVGAlignX) {
+      case ALIGN_LEFT:
+        translateX = -SVGViewBoxX * scaleX / 2;
+      break;
+      case ALIGN_CENTER:
+        translateX = Math.round(remainderX / 2) - SVGViewBoxX * scaleX / 2;
+      break;
+      case ALIGN_RIGHT:
+        translateX = remainderX - SVGViewBoxX * scaleX / 2;
+      break;
+    }
   }
+
+  const translationMatrix = translate(translateX, translateY);
+
   const matrix = transform(
     translationMatrix, //2
     scaleMatrix        //1

--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -104,8 +104,8 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
 
   const scaleMatrix = scale(scaleLevel, scaleLevel);
 
-  let translateX = -SVGViewBoxX * scaleX;
-  let translateY = -SVGViewBoxY * scaleY;
+  let translateX = -SVGViewBoxX * scaleX / 2;
+  let translateY = -SVGViewBoxY * scaleY / 2;
 
   // after fitting, SVG and the viewer will match in width (1) or in height (2)
   if (scaleX < scaleY) {

--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -96,7 +96,7 @@ export function fitSelection(value, selectionSVGPointX, selectionSVGPointY, sele
 }
 
 export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
-  let {viewerWidth, viewerHeight, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight} = value;
+  let {viewerWidth, viewerHeight, SVGMinX, SVGMinY, SVGWidth, SVGHeight} = value;
 
   let scaleX = viewerWidth / SVGWidth;
   let scaleY = viewerHeight / SVGHeight;
@@ -104,8 +104,8 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
 
   const scaleMatrix = scale(scaleLevel, scaleLevel);
 
-  let translateX = -SVGViewBoxX * scaleX;
-  let translateY = -SVGViewBoxY * scaleY;
+  let translateX = -SVGMinX * scaleX;
+  let translateY = -SVGMinY * scaleY;
 
   // after fitting, SVG and the viewer will match in width (1) or in height (2)
   if (scaleX < scaleY) {
@@ -113,13 +113,13 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
     let remainderY = viewerHeight - scaleX * SVGHeight;
     switch(SVGAlignY) {
       case ALIGN_TOP:
-        translateY = -SVGViewBoxY * scaleLevel;
+        translateY = -SVGMinY * scaleLevel;
       break;
       case ALIGN_CENTER:
-        translateY = Math.round(remainderY / 2) - SVGViewBoxY * scaleLevel;
+        translateY = Math.round(remainderY / 2) - SVGMinY * scaleLevel;
       break;
       case ALIGN_BOTTOM:
-        translateY = remainderY - SVGViewBoxY * scaleLevel;
+        translateY = remainderY - SVGMinY * scaleLevel;
       break;
     }
   } else {
@@ -127,13 +127,13 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
     let remainderX = viewerWidth - scaleY * SVGWidth;
     switch(SVGAlignX) {
       case ALIGN_LEFT:
-        translateX = -SVGViewBoxX * scaleLevel;
+        translateX = -SVGMinX * scaleLevel;
       break;
       case ALIGN_CENTER:
-        translateX = Math.round(remainderX / 2) - SVGViewBoxX * scaleLevel;
+        translateX = Math.round(remainderX / 2) - SVGMinX * scaleLevel;
       break;
       case ALIGN_RIGHT:
-        translateX = remainderX - SVGViewBoxX * scaleLevel;
+        translateX = remainderX - SVGMinX * scaleLevel;
       break;
     }
   }

--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -104,8 +104,8 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
 
   const scaleMatrix = scale(scaleLevel, scaleLevel);
 
-  let translateX = -SVGViewBoxX * scaleX / 2;
-  let translateY = -SVGViewBoxY * scaleY / 2;
+  let translateX = -SVGViewBoxX * scaleX;
+  let translateY = -SVGViewBoxY * scaleY;
 
   // after fitting, SVG and the viewer will match in width (1) or in height (2)
   if (scaleX < scaleY) {
@@ -113,34 +113,32 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
     let remainderY = viewerHeight - scaleX * SVGHeight;
     switch(SVGAlignY) {
       case ALIGN_TOP:
-        translateY = -SVGViewBoxY * scaleY / 2;
+        translateY = -SVGViewBoxY * scaleLevel;
       break;
       case ALIGN_CENTER:
-        translateY = Math.round(remainderY / 2) - SVGViewBoxY * scaleY / 2;
+        translateY = Math.round(remainderY / 2) - SVGViewBoxY * scaleLevel;
       break;
       case ALIGN_BOTTOM:
-        translateY = remainderY - SVGViewBoxY * scaleY / 2;
+        translateY = remainderY - SVGViewBoxY * scaleLevel;
       break;
     }
-  }
-  else {
+  } else {
     //(2) match in height, meaning scaled SVGWidth <= viewerWidth
     let remainderX = viewerWidth - scaleY * SVGWidth;
     switch(SVGAlignX) {
       case ALIGN_LEFT:
-        translateX = -SVGViewBoxX * scaleX / 2;
+        translateX = -SVGViewBoxX * scaleLevel;
       break;
       case ALIGN_CENTER:
-        translateX = Math.round(remainderX / 2) - SVGViewBoxX * scaleX / 2;
+        translateX = Math.round(remainderX / 2) - SVGViewBoxX * scaleLevel;
       break;
       case ALIGN_RIGHT:
-        translateX = remainderX - SVGViewBoxX * scaleX / 2;
+        translateX = remainderX - SVGViewBoxX * scaleLevel;
       break;
     }
   }
 
   const translationMatrix = translate(translateX, translateY);
-
   const matrix = transform(
     translationMatrix, //2
     scaleMatrix        //1

--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -96,14 +96,14 @@ export function fitSelection(value, selectionSVGPointX, selectionSVGPointY, sele
 }
 
 export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
-  let {viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGX, SVGY} = value;
+  let {viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGViewBoxX, SVGViewBoxY} = value;
 
   let scaleX = viewerWidth / SVGWidth;
   let scaleY = viewerHeight / SVGHeight;
   let scaleLevel = Math.min(scaleX, scaleY);
 
   const scaleMatrix = scale(scaleLevel, scaleLevel);
-  let translationMatrix = translate(-SVGX * scaleX, -SVGY / scaleY);
+  let translationMatrix = translate(-SVGViewBoxX * scaleX, -SVGViewBoxY * scaleY);
 
   // after fitting, SVG and the viewer will match in width (1) or in height (2)
   if (scaleX < scaleY) {
@@ -111,20 +111,19 @@ export function fitToViewer(value, SVGAlignX=ALIGN_LEFT, SVGAlignY=ALIGN_TOP) {
     let remainderY = viewerHeight - scaleX * SVGHeight;
 
     if (SVGAlignY === ALIGN_CENTER)
-      translationMatrix = translate(-SVGX * scaleX, (Math.round(remainderY / 2) - SVGY) * scaleY);
+      translationMatrix = translate(-SVGViewBoxX * scaleX, (Math.round(remainderY / 2) - SVGViewBoxY) * scaleY);
     if (SVGAlignY === ALIGN_BOTTOM)
-      translationMatrix = translate(-SVGX * scaleX, (remainderY - SVGY) * scaleY);
+      translationMatrix = translate(-SVGViewBoxX * scaleX, (remainderY - SVGViewBoxY) * scaleY);
   }
   else {
     //(2) match in height, meaning scaled SVGWidth <= viewerWidth
     let remainderX = viewerWidth - scaleY * SVGWidth;
 
     if (SVGAlignX === ALIGN_CENTER)
-      translationMatrix = translate((Math.round(remainderX / 2) - SVGX) * scaleX, -SVGY * scaleY);
+      translationMatrix = translate((Math.round(remainderX / 2) - SVGViewBoxX) * scaleX, -SVGViewBoxY * scaleY);
     if (SVGAlignX === ALIGN_RIGHT)
-      translationMatrix = translate((remainderX - SVGX) * scaleX, -SVGY * scaleY);
+      translationMatrix = translate((remainderX - SVGViewBoxX) * scaleX, -SVGViewBoxY * scaleY);
   }
-
   const matrix = transform(
     translationMatrix, //2
     scaleMatrix        //1

--- a/src/ui-miniature/miniature-mask.jsx
+++ b/src/ui-miniature/miniature-mask.jsx
@@ -4,21 +4,21 @@ import RandomUID from "../utils/RandomUID";
 
 const prefixID = 'react-svg-pan-zoom_miniature'
 
-function MiniatureMask({SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
+function MiniatureMask({SVGMinX, SVGMinY, SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
   const maskID = `${prefixID}_mask_${_uid}`
 
   return (
     <g>
       <defs>
         <mask id={maskID}>
-          <rect x={SVGViewBoxX} y={SVGViewBoxY} width={SVGWidth} height={SVGHeight} fill="#ffffff"/>
+          <rect x={SVGMinX} y={SVGMinY} width={SVGWidth} height={SVGHeight} fill="#ffffff"/>
           <rect x={x1} y={y1} width={x2 - x1} height={y2 - y1}/>
         </mask>
       </defs>
 
       <rect
-        x={SVGViewBoxX}
-        y={SVGViewBoxY}
+        x={SVGMinX}
+        y={SVGMinY}
         width={SVGWidth}
         height={SVGHeight}
         style={{
@@ -34,8 +34,8 @@ function MiniatureMask({SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, x1, y1, x
 MiniatureMask.propTypes = {
   SVGWidth: PropTypes.number.isRequired,
   SVGHeight: PropTypes.number.isRequired,
-  SVGViewBoxX: PropTypes.number.isRequired,
-  SVGViewBoxY: PropTypes.number.isRequired,
+  SVGMinX: PropTypes.number.isRequired,
+  SVGMinY: PropTypes.number.isRequired,
   x1: PropTypes.number.isRequired,
   y1: PropTypes.number.isRequired,
   x2: PropTypes.number.isRequired,

--- a/src/ui-miniature/miniature-mask.jsx
+++ b/src/ui-miniature/miniature-mask.jsx
@@ -4,21 +4,21 @@ import RandomUID from "../utils/RandomUID";
 
 const prefixID = 'react-svg-pan-zoom_miniature'
 
-function MiniatureMask({SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
+function MiniatureMask({SVGWidth, SVGHeight, SVGX, SVGY, x1, y1, x2, y2, zoomToFit, _uid}) {
   let maskID = `${prefixID}_mask_${_uid}`
 
   return (
     <g>
       <defs>
         <mask id={maskID}>
-          <rect x="0" y="0" width={SVGWidth} height={SVGHeight} fill="#ffffff"/>
+          <rect x={SVGX} y={SVGY} width={SVGWidth} height={SVGHeight} fill="#ffffff"/>
           <rect x={x1} y={y1} width={x2 - x1} height={y2 - y1}/>
         </mask>
       </defs>
 
       <rect
-        x="0"
-        y="0"
+        x={SVGX}
+        y={SVGY}
         width={SVGWidth}
         height={SVGHeight}
         style={{
@@ -34,6 +34,8 @@ function MiniatureMask({SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
 MiniatureMask.propTypes = {
   SVGWidth: PropTypes.number.isRequired,
   SVGHeight: PropTypes.number.isRequired,
+  SVGX: PropTypes.number.isRequired,
+  SVGY: PropTypes.number.isRequired,
   x1: PropTypes.number.isRequired,
   y1: PropTypes.number.isRequired,
   x2: PropTypes.number.isRequired,

--- a/src/ui-miniature/miniature-mask.jsx
+++ b/src/ui-miniature/miniature-mask.jsx
@@ -5,7 +5,8 @@ import RandomUID from "../utils/RandomUID";
 const prefixID = 'react-svg-pan-zoom_miniature'
 
 function MiniatureMask({SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
-  let maskID = `${prefixID}_mask_${_uid}`
+  const maskID = `${prefixID}_mask_${_uid}`
+
   return (
     <g>
       <defs>

--- a/src/ui-miniature/miniature-mask.jsx
+++ b/src/ui-miniature/miniature-mask.jsx
@@ -4,21 +4,20 @@ import RandomUID from "../utils/RandomUID";
 
 const prefixID = 'react-svg-pan-zoom_miniature'
 
-function MiniatureMask({SVGWidth, SVGHeight, SVGX, SVGY, x1, y1, x2, y2, zoomToFit, _uid}) {
+function MiniatureMask({SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, x1, y1, x2, y2, zoomToFit, _uid}) {
   let maskID = `${prefixID}_mask_${_uid}`
-
   return (
     <g>
       <defs>
         <mask id={maskID}>
-          <rect x={SVGX} y={SVGY} width={SVGWidth} height={SVGHeight} fill="#ffffff"/>
+          <rect x={SVGViewBoxX} y={SVGViewBoxY} width={SVGWidth} height={SVGHeight} fill="#ffffff"/>
           <rect x={x1} y={y1} width={x2 - x1} height={y2 - y1}/>
         </mask>
       </defs>
 
       <rect
-        x={SVGX}
-        y={SVGY}
+        x={SVGViewBoxX}
+        y={SVGViewBoxY}
         width={SVGWidth}
         height={SVGHeight}
         style={{
@@ -34,8 +33,8 @@ function MiniatureMask({SVGWidth, SVGHeight, SVGX, SVGY, x1, y1, x2, y2, zoomToF
 MiniatureMask.propTypes = {
   SVGWidth: PropTypes.number.isRequired,
   SVGHeight: PropTypes.number.isRequired,
-  SVGX: PropTypes.number.isRequired,
-  SVGY: PropTypes.number.isRequired,
+  SVGViewBoxX: PropTypes.number.isRequired,
+  SVGViewBoxY: PropTypes.number.isRequired,
   x1: PropTypes.number.isRequired,
   y1: PropTypes.number.isRequired,
   x2: PropTypes.number.isRequired,

--- a/src/ui-miniature/miniature.jsx
+++ b/src/ui-miniature/miniature.jsx
@@ -10,7 +10,7 @@ const {min, max} = Math;
 export default function Miniature(props) {
 
   let {value, onChangeValue, children, position, background, SVGBackground, width: miniatureWidth, height: miniatureHeight} = props;
-  let {SVGWidth, SVGHeight, SVGX, SVGY, viewerWidth, viewerHeight} = value;
+  let {SVGWidth, SVGHeight, SVGViewBoxX, SVGViewBoxY, viewerWidth, viewerHeight} = value;
 
   let ratio = SVGHeight / SVGWidth;
 
@@ -45,8 +45,8 @@ export default function Miniature(props) {
   };
 
   let centerTranslation = ratio >= 1
-    ? `translate(${(miniatureWidth - (SVGWidth * zoomToFit)) / 2}, 0)`
-    : `translate(0, ${(miniatureHeight - (SVGHeight * zoomToFit)) / 2})`;
+    ? `translate(${(miniatureWidth / 2 - SVGWidth / 2 + SVGViewBoxX) * zoomToFit}, ${-SVGViewBoxY * zoomToFit})`
+    : `translate(${-SVGViewBoxX * zoomToFit}, ${(miniatureHeight / 2 - SVGHeight / 2 + SVGViewBoxY) * zoomToFit})`;
 
   return (
     <div role="navigation" style={style}>
@@ -59,8 +59,8 @@ export default function Miniature(props) {
 
             <rect
               fill={SVGBackground}
-              x={value.SVGX}
-              y={value.SVGY}
+              x={value.SVGViewBoxX}
+              y={value.SVGViewBoxY}
               width={value.SVGWidth}
               height={value.SVGHeight}/>
 
@@ -69,8 +69,8 @@ export default function Miniature(props) {
             <MiniatureMask
               SVGWidth={SVGWidth}
               SVGHeight={SVGHeight}
-              SVGX={SVGX}
-              SVGY={SVGY}
+              SVGViewBoxX={SVGViewBoxX}
+              SVGViewBoxY={SVGViewBoxY}
               x1={x1}
               y1={y1}
               x2={x2}

--- a/src/ui-miniature/miniature.jsx
+++ b/src/ui-miniature/miniature.jsx
@@ -10,7 +10,7 @@ const {min, max} = Math;
 export default function Miniature(props) {
 
   let {value, onChangeValue, children, position, background, SVGBackground, width: miniatureWidth, height: miniatureHeight} = props;
-  let {SVGWidth, SVGHeight, SVGViewBoxX, SVGViewBoxY, viewerWidth, viewerHeight} = value;
+  let {SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, viewerWidth, viewerHeight} = value;
 
   let ratio = SVGHeight / SVGWidth;
 
@@ -59,10 +59,10 @@ export default function Miniature(props) {
 
             <rect
               fill={SVGBackground}
-              x={value.SVGViewBoxX}
-              y={value.SVGViewBoxY}
-              width={value.SVGWidth}
-              height={value.SVGHeight}/>
+              x={SVGViewBoxX}
+              y={SVGViewBoxY}
+              width={SVGWidth}
+              height={SVGHeight}/>
 
             {children}
 

--- a/src/ui-miniature/miniature.jsx
+++ b/src/ui-miniature/miniature.jsx
@@ -10,7 +10,7 @@ const {min, max} = Math;
 export default function Miniature(props) {
 
   let {value, onChangeValue, children, position, background, SVGBackground, width: miniatureWidth, height: miniatureHeight} = props;
-  let {SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, viewerWidth, viewerHeight} = value;
+  let {SVGMinX, SVGMinY, SVGWidth, SVGHeight, viewerWidth, viewerHeight} = value;
 
   let ratio = SVGHeight / SVGWidth;
 
@@ -45,8 +45,8 @@ export default function Miniature(props) {
   };
 
   let centerTranslation = ratio >= 1
-    ? `translate(${(miniatureWidth - (SVGWidth * zoomToFit)) / 2 - SVGViewBoxX * zoomToFit}, ${ - SVGViewBoxY * zoomToFit})`
-    : `translate(${ - SVGViewBoxX * zoomToFit}, ${(miniatureHeight - (SVGHeight * zoomToFit)) / 2 - SVGViewBoxY * zoomToFit})`;
+    ? `translate(${(miniatureWidth - (SVGWidth * zoomToFit)) / 2 - SVGMinX * zoomToFit}, ${ - SVGMinY * zoomToFit})`
+    : `translate(${ - SVGMinX * zoomToFit}, ${(miniatureHeight - (SVGHeight * zoomToFit)) / 2 - SVGMinY * zoomToFit})`;
 
   return (
     <div role="navigation" style={style}>
@@ -59,8 +59,8 @@ export default function Miniature(props) {
 
             <rect
               fill={SVGBackground}
-              x={SVGViewBoxX}
-              y={SVGViewBoxY}
+              x={SVGMinX}
+              y={SVGMinY}
               width={SVGWidth}
               height={SVGHeight}/>
 
@@ -69,8 +69,8 @@ export default function Miniature(props) {
             <MiniatureMask
               SVGWidth={SVGWidth}
               SVGHeight={SVGHeight}
-              SVGViewBoxX={SVGViewBoxX}
-              SVGViewBoxY={SVGViewBoxY}
+              SVGMinX={SVGMinX}
+              SVGMinY={SVGMinY}
               x1={x1}
               y1={y1}
               x2={x2}

--- a/src/ui-miniature/miniature.jsx
+++ b/src/ui-miniature/miniature.jsx
@@ -45,8 +45,8 @@ export default function Miniature(props) {
   };
 
   let centerTranslation = ratio >= 1
-    ? `translate(${(miniatureWidth / 2 - SVGWidth / 2 + SVGViewBoxX) * zoomToFit}, ${-SVGViewBoxY * zoomToFit})`
-    : `translate(${-SVGViewBoxX * zoomToFit}, ${(miniatureHeight / 2 - SVGHeight / 2 + SVGViewBoxY) * zoomToFit})`;
+    ? `translate(${(miniatureWidth - (SVGWidth * zoomToFit)) / 2 - SVGViewBoxX * zoomToFit}, ${ - SVGViewBoxY * zoomToFit})`
+    : `translate(${ - SVGViewBoxX * zoomToFit}, ${(miniatureHeight - (SVGHeight * zoomToFit)) / 2 - SVGViewBoxY * zoomToFit})`;
 
   return (
     <div role="navigation" style={style}>

--- a/src/ui-miniature/miniature.jsx
+++ b/src/ui-miniature/miniature.jsx
@@ -10,7 +10,7 @@ const {min, max} = Math;
 export default function Miniature(props) {
 
   let {value, onChangeValue, children, position, background, SVGBackground, width: miniatureWidth, height: miniatureHeight} = props;
-  let {SVGWidth, SVGHeight, viewerWidth, viewerHeight} = value;
+  let {SVGWidth, SVGHeight, SVGX, SVGY, viewerWidth, viewerHeight} = value;
 
   let ratio = SVGHeight / SVGWidth;
 
@@ -59,8 +59,8 @@ export default function Miniature(props) {
 
             <rect
               fill={SVGBackground}
-              x={0}
-              y={0}
+              x={value.SVGX}
+              y={value.SVGY}
               width={value.SVGWidth}
               height={value.SVGHeight}/>
 
@@ -69,6 +69,8 @@ export default function Miniature(props) {
             <MiniatureMask
               SVGWidth={SVGWidth}
               SVGHeight={SVGHeight}
+              SVGX={SVGX}
+              SVGY={SVGY}
               x1={x1}
               y1={y1}
               x2={x2}

--- a/src/utils/ViewBoxParser.js
+++ b/src/utils/ViewBoxParser.js
@@ -1,3 +1,7 @@
-export default function parseViewBox(viewBox) {
-  return viewBox.split(' ').map(parseFloat);
+export default function parseViewBox(viewBoxString) {
+  // viewBox specs: https://www.w3.org/TR/SVG/coords.html#ViewBoxAttribute
+  return viewBoxString
+    .split(/[ ,]/) // split optional comma
+    .filter(Boolean) // remove empty strings
+    .map(Number); // cast to Number
 }

--- a/src/utils/ViewBoxParser.js
+++ b/src/utils/ViewBoxParser.js
@@ -1,0 +1,3 @@
+export default function parseViewBox(viewBox) {
+  return viewBox.split(' ').map(parseFloat);
+}

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -107,7 +107,7 @@ export default class ReactSVGPanZoom extends React.Component {
       prevSVGX !== SVGX ||
       prevSVGY !== SVGY
     ) {
-      nextValue = setSVGSize(nextValue, SVGWidth, SVGHeight, prevSVGX, prevSVGY);
+      nextValue = setSVGSize(nextValue, SVGWidth, SVGHeight, SVGX, SVGY);
       needUpdate = true;
     }
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -23,6 +23,7 @@ import {
   onMouseUp,
   onWheel
 } from './features/interactions';
+import parseViewBox from './utils/ViewBoxParser';
 import {onTouchCancel, onTouchEnd, onTouchMove, onTouchStart} from './features/interactions-touch';
 
 import {fitSelection, fitToViewer, zoom, zoomOnViewerCenter} from './features/zoom';
@@ -66,7 +67,7 @@ export default class ReactSVGPanZoom extends React.Component {
     const {withViewBox: SVGViewBox} = children.props;
     let defaultValue;
     if (SVGViewBox) {
-      const [SVGMinX, SVGMinY, SVGWidth, SVGHeight] = SVGViewBox.split(' ').map(parseFloat);
+      const [SVGMinX, SVGMinY, SVGWidth, SVGHeight] = parseViewBox(SVGViewBox);
       defaultValue = getDefaultValue(viewerWidth, viewerHeight, SVGMinX, SVGMinY, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax)
     } else {
       const {width: SVGWidth, height: SVGHeight} = children.props;
@@ -103,7 +104,7 @@ export default class ReactSVGPanZoom extends React.Component {
     const {withViewBox: SVGViewBox} = props.children.props;
     if (SVGViewBox) {
       // if the withViewBox prop is specified
-      const [x, y, width, height] = SVGViewBox.split(' ').map(parseFloat);
+      const [x, y, width, height] = parseViewBox(SVGViewBox);
 
       if(value.SVGMinX !== x || value.SVGMinY !== y || value.SVGWidth !== width || value.SVGHeight !== height) {
         nextValue = setSVGViewBox(nextValue, x, y, width, height);

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -66,8 +66,8 @@ export default class ReactSVGPanZoom extends React.Component {
     const {withViewBox: SVGViewBox} = children.props;
     let defaultValue;
     if (SVGViewBox) {
-      const [SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight] = SVGViewBox.split(' ').map(parseFloat);
-      defaultValue = getDefaultValue(viewerWidth, viewerHeight, SVGViewBoxX, SVGViewBoxY, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax)
+      const [SVGMinX, SVGMinY, SVGWidth, SVGHeight] = SVGViewBox.split(' ').map(parseFloat);
+      defaultValue = getDefaultValue(viewerWidth, viewerHeight, SVGMinX, SVGMinY, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax)
     } else {
       const {width: SVGWidth, height: SVGHeight} = children.props;
       defaultValue = getDefaultValue(viewerWidth, viewerHeight, 0, 0, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax)
@@ -105,7 +105,7 @@ export default class ReactSVGPanZoom extends React.Component {
       // if the withViewBox prop is specified
       const [x, y, width, height] = SVGViewBox.split(' ').map(parseFloat);
 
-      if(value.SVGViewBoxX !== x || value.SVGViewBoxY !== y || value.SVGWidth !== width || value.SVGHeight !== height) {
+      if(value.SVGMinX !== x || value.SVGMinY !== y || value.SVGWidth !== width || value.SVGHeight !== height) {
         nextValue = setSVGViewBox(nextValue, x, y, width, height);
         needUpdate = true;
       }
@@ -380,8 +380,8 @@ export default class ReactSVGPanZoom extends React.Component {
             <rect
               fill={this.props.SVGBackground}
               style={this.props.SVGStyle}
-              x={value.SVGViewBoxX || 0}
-              y={value.SVGViewBoxY || 0}
+              x={value.SVGMinX || 0}
+              y={value.SVGMinY || 0}
               width={value.SVGWidth}
               height={value.SVGHeight}/>
             <g>
@@ -463,8 +463,8 @@ ReactSVGPanZoom.propTypes = {
       f: PropTypes.number.isRequired,
       viewerWidth: PropTypes.number.isRequired,
       viewerHeight: PropTypes.number.isRequired,
-      SVGViewBoxX: PropTypes.number.isRequired,
-      SVGViewBoxY: PropTypes.number.isRequired,
+      SVGMinX: PropTypes.number.isRequired,
+      SVGMinY: PropTypes.number.isRequired,
       SVGWidth: PropTypes.number.isRequired,
       SVGHeight: PropTypes.number.isRequired,
       startX: PropTypes.number,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -63,14 +63,14 @@ export default class ReactSVGPanZoom extends React.Component {
 
   constructor(props, context) {
     const {value, width: viewerWidth, height: viewerHeight, scaleFactorMin, scaleFactorMax, children} = props;
-    const {width: SVGWidth, height: SVGHeight} = children.props;
+    const {width: SVGWidth, height: SVGHeight, x: SVGX, y: SVGY} = children.props;
 
     super(props, context);
     this.ViewerDOM = null;
     this.state = {
       pointerX: null,
       pointerY: null,
-      defaultValue: getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, scaleFactorMin, scaleFactorMax)
+      defaultValue: getDefaultValue(viewerWidth, viewerHeight, SVGWidth, SVGHeight, SVGX, SVGY, scaleFactorMin, scaleFactorMax)
     }
     this.autoPanLoop = this.autoPanLoop.bind(this);
 
@@ -99,13 +99,15 @@ export default class ReactSVGPanZoom extends React.Component {
       needUpdate = true;
     }
 
-    let {width: SVGWidth, height: SVGHeight} = props.children.props;
-    let {width: prevSVGWidth, height: prevSVGHeight} = prevProps.children.props;
+    let {width: SVGWidth, height: SVGHeight, x: SVGX, y: SVGY} = props.children.props;
+    let {width: prevSVGWidth, height: prevSVGHeight, x: prevSVGX, y: prevSVGY} = prevProps.children.props;
     if (
       prevSVGWidth !== SVGWidth ||
-      prevSVGHeight !== SVGHeight
+      prevSVGHeight !== SVGHeight ||
+      prevSVGX !== SVGX ||
+      prevSVGY !== SVGY
     ) {
-      nextValue = setSVGSize(nextValue, SVGWidth, SVGHeight);
+      nextValue = setSVGSize(nextValue, SVGWidth, SVGHeight, prevSVGX, prevSVGY);
       needUpdate = true;
     }
 
@@ -361,8 +363,8 @@ export default class ReactSVGPanZoom extends React.Component {
             <rect
               fill={this.props.SVGBackground}
               style={this.props.SVGStyle}
-              x={0}
-              y={0}
+              x={value.SVGX}
+              y={value.SVGY}
               width={value.SVGWidth}
               height={value.SVGHeight}/>
             <g>
@@ -446,6 +448,8 @@ ReactSVGPanZoom.propTypes = {
       viewerHeight: PropTypes.number.isRequired,
       SVGWidth: PropTypes.number.isRequired,
       SVGHeight: PropTypes.number.isRequired,
+      SVGX: PropTypes.number.isRequired,
+      SVGY: PropTypes.number.isRequired,
       startX: PropTypes.number,
       startY: PropTypes.number,
       endX: PropTypes.number,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -64,7 +64,7 @@ export default class ReactSVGPanZoom extends React.Component {
 
   constructor(props, context) {
     const {value, width: viewerWidth, height: viewerHeight, scaleFactorMin, scaleFactorMax, children} = props;
-    const {withViewBox: SVGViewBox} = children.props;
+    const {viewBox: SVGViewBox} = children.props;
     let defaultValue;
     if (SVGViewBox) {
       const [SVGMinX, SVGMinY, SVGWidth, SVGHeight] = parseViewBox(SVGViewBox);
@@ -101,9 +101,9 @@ export default class ReactSVGPanZoom extends React.Component {
     }
 
     // This block checks the size of the SVG
-    const {withViewBox: SVGViewBox} = props.children.props;
+    const {viewBox: SVGViewBox} = props.children.props;
     if (SVGViewBox) {
-      // if the withViewBox prop is specified
+      // if the viewBox prop is specified
       const [x, y, width, height] = parseViewBox(SVGViewBox);
 
       if(value.SVGMinX !== x || value.SVGMinY !== y || value.SVGWidth !== width || value.SVGHeight !== height) {
@@ -615,9 +615,9 @@ ReactSVGPanZoom.propTypes = {
     }
     if (
       (!prop.props.hasOwnProperty('width') || !prop.props.hasOwnProperty('height')) &&
-      (!prop.props.hasOwnProperty('withViewBox'))
+      (!prop.props.hasOwnProperty('viewBox'))
     ) {
-      return new Error('SVG should have props `width` and `height` or `withViewBox`');
+      return new Error('SVG should have props `width` and `height` or `viewBox`');
     }
 
   }

--- a/storybook/stories/ViewboxStory.jsx
+++ b/storybook/stories/ViewboxStory.jsx
@@ -35,7 +35,7 @@ export default class ViewboxStory extends React.Component {
         >
 
           <svg
-            width="100" height="100"
+            width={100} height={100}
             withViewBox="10 10 80 80"
           >
 

--- a/storybook/stories/ViewboxStory.jsx
+++ b/storybook/stories/ViewboxStory.jsx
@@ -1,0 +1,55 @@
+import React, {StrictMode} from 'react';
+import {action} from '@storybook/addon-actions';
+import {noArgsDecorator, viewerMouseEventDecorator} from './actions-decorator';
+
+import {UncontrolledReactSVGPanZoom} from '../../src/index';
+import {boolean} from "@storybook/addon-knobs";
+
+export default class ViewboxStory extends React.Component {
+  constructor(props) {
+    super(props)
+    this.Viewer = null;
+  }
+
+  componentDidMount() {
+    this.Viewer.fitToViewer();
+  }
+
+  render() {
+    return (
+      <StrictMode>
+
+        <UncontrolledReactSVGPanZoom
+          width={400} height={400}
+
+          ref={Viewer => this.Viewer = Viewer}
+
+          onClick={viewerMouseEventDecorator('onClick')}
+
+          onChangeValue={noArgsDecorator('onChangeValue')}
+          onChangeTool={action('onChangeTool')}
+
+          detectAutoPan={boolean('detectAutoPan', false)}
+          detectWheel={boolean('detectWheel', false)}
+          detectPinchGesture={boolean('detectPinchGesture', false)}
+        >
+
+          <svg
+            width="100" height="100"
+            withViewBox="10 10 80 80"
+          >
+
+            <rect x="20" y="20" width="60" height="60" fill="yellow"/>
+            <circle cx="20" cy="20" r="4" fill="red"/>
+            <circle cx="80" cy="80" r="4" fill="red"/>
+
+            <circle cx="0" cy="0" r="4" fill="blue"/>
+            <circle cx="100" cy="100" r="4" fill="blue"/>
+
+            <circle cx="50" cy="50" r="2" fill="black"/>
+          </svg>
+        </UncontrolledReactSVGPanZoom>
+      </StrictMode>
+    )
+  }
+}

--- a/storybook/stories/index.js
+++ b/storybook/stories/index.js
@@ -10,6 +10,7 @@ import AutosizerViewer from './AutosizerViewer'
 import DifferentSizesStory from './DifferentSizesStory';
 import RuntimeResizeStory from "./RuntimeResizeStory";
 import UncontrolledViewerStory from "./UncontrolledViewerStory";
+import ViewboxStory from './ViewboxStory'
 
 storiesOf('React SVG Pan Zoom', module)
   .addDecorator(withKnobs)
@@ -20,5 +21,6 @@ storiesOf('React SVG Pan Zoom', module)
   .add('Autosizer viewer', () => <AutosizerViewer />)
   .add('Different Sizes', () => <DifferentSizesStory />)
   .add('Runtime Resize', () =>  <RuntimeResizeStory />)
+  .add('Viewbox prop', () => <ViewboxStory />)
 
 


### PR DESCRIPTION
This pull request is analogous to #88 by @kheyse-oqton but updated and merged with the latest version of this library. It facilitates the use of the `viewBox` property of the main `svg`.

FROM:
```
<svg 
  width={1440} 
  height={1440}
>
```

TO:
```
<svg
  width={1440}
  height={1440}
  viewBox={`400, 100, 1440, 1440`}
>
```

This centers the view of the main svg and the miniature around the specified viewBox.

The only obvious side effect for current users is that in the unlikely scenario that they have `viewBox` specified, the centering will be affected. This is an unlikely case, because would be an unused property in the current version of this component.