### PR TITLE
Added SVGIsReactComponent prop to allow React child

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -48,6 +48,7 @@
 | toolbarProps.SVGAlignX | `left` | one of `left`, `center`, `right` | X Alignment used for "Fit to Viewer" action |
 | toolbarProps.SVGAlignY | `top` | one of `top`, `center`, `bottom` | Y Alignment used for "Fit to Viewer" action |
 | toolbarProps.activeToolColor | `#1CA6FC` | String | Color of active and hovered tool icons |
+| SVGIsReactComponent | `false` | Boolean | Set this it `true` if rather than an `svg` element, you're wrapping a React component that renders SVG output |
 
 \* handler available only with the tool `none` or `auto`
 

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -389,7 +389,7 @@ export default class ReactSVGPanZoom extends React.Component {
               width={value.SVGWidth}
               height={value.SVGHeight}/>
             <g>
-              {props.children.props.children}
+              {props.SVGIsReactComponent ? props.children : props.children.props.children}
             </g>
           </g>
 
@@ -434,7 +434,7 @@ export default class ReactSVGPanZoom extends React.Component {
             onChangeValue={value => this.setValue(value)}
             SVGBackground={this.props.SVGBackground}
           >
-            {props.children.props.children}
+            {props.SVGIsReactComponent ? props.children : props.children.props.children}
           </CustomMiniature>
         }
       </div>
@@ -603,8 +603,9 @@ ReactSVGPanZoom.propTypes = {
   /**************************************************************************/
   /* Children Check                                                         */
   /**************************************************************************/
-  //accept only one node SVG
+  //accept only one node SVG unless SVGIsReactComponent is set
   children: function (props, propName, componentName) {
+    if (props.SVGIsReactComponent) return
     // Only accept a single child, of the appropriate type
     //credits: http://www.mattzabriskie.com/blog/react-validating-children
     let prop = props[propName];
@@ -646,4 +647,5 @@ ReactSVGPanZoom.defaultProps = {
   toolbarProps: {},
   customMiniature: Miniature,
   miniatureProps: {},
+  SVGIsReactComponent: false
 };


### PR DESCRIPTION
This pull request adds support for using this component to add pan/zoom to React components that render SVG (currently, it only works for native svg elements).

I have a react component that renders SVG, and was looking to add pan/zoom to it.
react-svg-pan-zoom would be perfect for that, except that it checks that it gets passed a single child of type `svg`. That check fails when you wrap another React component.

I have added a prop named `SVGIsReactComponent` that has a default value of `false`. Setting it to `true` will skip the props.children check and simply render the wrapped component.

It works fine for this use-case:
![Screenshot_2020-04-19 hugo](https://user-images.githubusercontent.com/1708494/79694182-172c9580-826f-11ea-82e1-32dff022e9d5.png)

The wrapped component not only displays correctly, I can also still interact with it.

This should have no impact whatsoever if the `SVGIsReactComponent` prop is not set (or set to `false`).