### PR TITLE
Remove unused import "tipNoViewer" from index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import {tipNoViewer} from "./migration-tips";
-
 export {default as ReactSVGPanZoom} from './viewer';
 export {default as UncontrolledReactSVGPanZoom} from './uncontrolled-viewer';
 export {default as Toolbar} from './ui-toolbar/toolbar';


### PR DESCRIPTION
This pull request fixes the following error :

```
Error: Build failed with 1 error:
node_modules/.pnpm/react-svg-pan-zoom@3.12.0/node_modules/react-svg-pan-zoom/build-es/index.js:1:9: ERROR: No matching export in "node_modules/.pnpm/react-svg-pan-zoom@3.12.0/node_modules/react-svg-pan-zoom/build-es/migration-tips.js" for import "tipNoViewer"
```

It removes the unused imported "tipNoViewer" which was previously used as an error message showing the documentation for v1 to v2 migration. Which was also removed in the commit [becc3c7](https://github.com/chrvadala/react-svg-pan-zoom/commit/becc3c7cc18c36e944d2a2a326a15b304ad476d6)