### PR TITLE
feat: make viewer stay inside SVG boundaries

### DIFF
--- a/src/features/zoom.js
+++ b/src/features/zoom.js
@@ -1,4 +1,4 @@
-import {fromObject, scale, transform, translate} from 'transformation-matrix';
+import {fromObject, scale, transform, translate, applyToPoints} from 'transformation-matrix';
 
 import {
   ACTION_ZOOM, MODE_IDLE, MODE_ZOOMING,
@@ -34,14 +34,18 @@ export function limitZoomLevel(value, matrix) {
   });
 }
 
-export function zoom(value, SVGPointX, SVGPointY, scaleFactor) {
+export function zoom(value, SVGPointX, SVGPointY, scaleFactor, props) {
+  let matrix = transform(
+    fromObject(value)
+  );
+
   if (isZoomLevelGoingOutOfBounds(value, scaleFactor)) {
       // Do not change translation and scale of value
       return value;
   }
 
-  const matrix = transform(
-    fromObject(value),
+  matrix = transform(
+    matrix,
     translate(SVGPointX, SVGPointY),
     scale(scaleFactor, scaleFactor),
     translate(-SVGPointX, -SVGPointY)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -594,6 +594,11 @@ ReactSVGPanZoom.propTypes = {
   preventPanOutside: PropTypes.bool,
 
   /**
+   * if enabled, restricts the viewer so it cannot be moved or zoomed outside the SVG boundaries
+   */
+  constrainToSVGBounds: PropTypes.bool,
+
+  /**
   * how much scale in or out
   */
   scaleFactor: PropTypes.number,
@@ -700,6 +705,7 @@ ReactSVGPanZoom.defaultProps = {
   detectPinchGesture: true,
   modifierKeys: ["Alt", "Shift", "Control"],
   preventPanOutside: true,
+  constrainToSVGBounds: false,
   scaleFactor: 1.1,
   scaleFactorOnWheel: 1.06,
   disableZoomWithToolAuto: false,

--- a/test/features/pan.spec.js
+++ b/test/features/pan.spec.js
@@ -26,21 +26,35 @@ describe("atomic pan", () => {
     expect(testSVGBBox(value1)).toEqual([50, 70, 120, 210])
   })
 
-  test("pan limit", () => {
+  test("pan with preventPanOutside", () => {
     const value = getDefaultValue(
       200, 200,       //viewer 200x200
       0, 0, 400, 400, //svg 400x400
     )
 
     //move to bottom right limit
-    const value1 = pan(value, 500, 700, 20)
+    const value1 = pan(value, 500, 700, { preventPanOutside: true })
     expect(testSVGBBox(value1)).toEqual([180, 180, expect.any(Number), expect.any(Number)])
 
     //move to top left limit
-    const value2 = pan(value, -500, -700, 20)
+    const value2 = pan(value, -500, -700, { preventPanOutside: true })
     expect(testSVGBBox(value2)).toEqual([expect.any(Number), expect.any(Number), 20, 20])
   })
 
+  test("pan with constrainToSVGBounds", () => {
+    const value = getDefaultValue(
+      200, 200,       // viewer 200x200
+      0, 0, 400, 400  // SVG 400x400
+    );
+
+    // Move to bottom right limit with constrainToSVGBounds
+    const value1 = pan(value, 500, 700, { constrainToSVGBounds: true });
+    expect(testSVGBBox(value1)).toEqual([0, 0, expect.any(Number), expect.any(Number)]);
+
+    // Move to top left limit with constrainToSVGBounds
+    const value2 = pan(value, -500, -700, { constrainToSVGBounds: true });
+    expect(testSVGBBox(value2)).toEqual([expect.any(Number), expect.any(Number), 200, 200]);
+  });
 })
 
 test("pan lifecycle", () => {


### PR DESCRIPTION

### Pull Request Title: 
Implement Pan and Zoom Constraints for SVG Viewer

### Description:
This PR addresses issue #143 by implementing the following improvements to enhance the user experience within the SVG viewer:

1. **Pan restrictions**: Users can no longer drag the SVG outside its boundaries when the `constrainToSVGBounds` flag is set to `true`.
2. **Automatic Fit to Viewer**: Calls `fitToViewer` when the SVG does not fully fit within the viewer. 
   - I am open to feedback on this approach; an alternative could be to block all interactions except for zooming in.
3. **Zoom restrictions**: Zoom functionality is restricted using `fitToViewer`, preventing users from excessively zooming out beyond the SVG boundaries.

### How to Test
To test these new features:
1. Run the application with `npm run start`.
2. Navigate to **StandardViewer**.
3. In **Controls**, set the `constrainToSVGBounds` flag to `true`.

### Related Issues:
- https://github.com/chrvadala/react-svg-pan-zoom/issues/143